### PR TITLE
update LocalStack reference in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Amplify LocalStack Plugin
 ![example workflow](https://github.com/localstack/amplify-localstack/actions/workflows/ci.yml/badge.svg)
 
-**Amplify CLI** Plugin to support running against [LocalStack](https://github.com/localstack/localstack)
+**Amplify CLI** Plugin to support running against [LocalStack for AWS](https://www.localstack.cloud/localstack-for-aws)
 
 This plugin allows the amplify CLI tool to create resources directly on your local machine. Any request to AWS is redirected to a running LocalStack instance.
 


### PR DESCRIPTION
## Motivation
The README currently points towards the GitHub repo `localstack/localstack`. After the [consolidation of our images](https://blog.localstack.cloud/the-road-ahead-for-localstack/) this repo will not be the primary point for our code though.
This is why this PR updates this link to point towards our website.

## Changes
- Update link in README